### PR TITLE
feat: add deploy-to-cdn-step in github action

### DIFF
--- a/.github/workflows/linode_stage.yaml
+++ b/.github/workflows/linode_stage.yaml
@@ -20,6 +20,14 @@ jobs:
       run: yarn run lint
     - name: Run build task
       run: NODE_ENV=production SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} SENTRY_AUTO_RELEASE=true yarn run build
+    - name: Upload static assets to cdn's S3
+      uses: shallwefootball/s3-upload-action@master
+      with:
+        aws_key_id: ${{ secrets.CDN_AWS_KEY_ID }}
+        aws_secret_access_key: ${{ secrets.CDN_AWS_SECRET_ACCESS_KEY }}
+        aws_bucket: ${{ secrets.CDN_AWS_BUCKET }}
+        source_dir: '.next/static'
+        destination_dir: '_next/static'
     - name: Deploy to Server
       uses: easingthemes/ssh-deploy@main
       env:

--- a/next.config.js
+++ b/next.config.js
@@ -5,11 +5,12 @@
 
 const { withSentryConfig } = require('@sentry/nextjs');
 
-
-let SENTRY_AUTO_RELEASE = process.env.SENTRY_AUTO_RELEASE === 'true';
+const isProd = process.env.NODE_ENV === 'production'
+const SENTRY_AUTO_RELEASE = process.env.SENTRY_AUTO_RELEASE === 'true';
 
 const moduleExports = {
   reactStrictMode: true,
+  assetPrefix: isProd ? 'https://cdn1.itseed.tw' : '',
   sentry: {
     disableServerWebpackPlugin: !SENTRY_AUTO_RELEASE,
     disableClientWebpackPlugin: !SENTRY_AUTO_RELEASE,


### PR DESCRIPTION
# Description

Using CDN to optimize the latency and decrease load for web service.
The change will add
- one more step in CD, and that' is for deploying assets to aws cdn.
- prefix into asset links 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CD will be trigger when deploying code to staging, and now we will deploy the assets files to s3 and be binded to CDN.
![image](https://user-images.githubusercontent.com/16770691/142233802-974064c8-cf52-4a0a-8d2b-06ac75d99532.png)

The CDN will mount with the domain `cdn1.itseed.tw`.
So we can use this to be the prefix of asset link.

http://stage.itseed.tw/
![image](https://user-images.githubusercontent.com/16770691/142233611-a2927750-730a-4a76-9d1b-0f132bcad5e8.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- WIP I have made corresponding changes to the documentation
- N/A My changes generate no new warnings
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A New and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules