### PR TITLE
feat: add release github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: conventionally release
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  conventionally-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Conventional Changelog Action
+      id: changelog
+      uses: TriPSs/conventional-changelog-action@v3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        output-file: "false"
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      if: ${{ steps.changelog.outputs.skipped == 'false' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.github_token }}
+      with:
+        tag_name: ${{ steps.changelog.outputs.tag }}
+        release_name: ${{ steps.changelog.outputs.tag }}
+        body: ${{ steps.changelog.outputs.clean_changelog }}


### PR DESCRIPTION
# Description

Integrate with conventionally-release github action for automatically release.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Merge some code to main and the `release` action will be trigged.
And the action will collect the conventional commits and make a tag and release for the mergement.

Result of testing.

https://github.com/ITSeed-Official/itseed_frontend/runs/4241459194?check_suite_focus=true
![image](https://user-images.githubusercontent.com/16770691/142251933-ddcf26f1-d1a1-4dcd-8160-a58be4946f50.png)

![image](https://user-images.githubusercontent.com/16770691/142251743-df226184-bbd4-4157-acc1-e41e78e2a22d.png)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- WIP I have made corresponding changes to the documentation
- N/A My changes generate no new warnings
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A New and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules