### PR TITLE
refactor: let Banner can customize

### DIFF
--- a/components/molecules/BannerContainer/BannerContainer.tsx
+++ b/components/molecules/BannerContainer/BannerContainer.tsx
@@ -13,10 +13,20 @@ import styles from "./BannerContainer.module.scss";
 type BannerContainerProperty = {
   className?: string;
   backgroundImage?: string;
+  bigTitle?: string;
+  subTitle?: string;
+  subText?: string;
+  buttonText?: string;
+  showSummaryInfo?: boolean;
 };
 
 const BannerContainer: FC<BannerContainerProperty> = ({
   backgroundImage = "",
+  bigTitle = "",
+  subTitle = "",
+  subText = "",
+  buttonText = "",
+  showSummaryInfo = false,
   className,
 }) => {
   return (
@@ -26,15 +36,15 @@ const BannerContainer: FC<BannerContainerProperty> = ({
     >
       <SectionWrapper className={styles.bannerContent}>
         <div className={styles.bannerInfo}>
-          <SectionBigTitle title="擁抱每一份獨特" />
-          <SubTitle
-            title="第十九屆資訊種子培訓計畫"
-            className={styles.subTitle}
-          />
-          <p>報名時間：2022/6/1-7/1</p>
-          <Button text="立即報名" className={styles.button} />
+          {bigTitle && <SectionBigTitle title={bigTitle} />}
+          {subTitle && (
+            <SubTitle title={subTitle} className={styles.subTitle} />
+          )}
+
+          {subText && <p>{subText}</p>}
+          {buttonText && <Button text={buttonText} className={styles.button} />}
         </div>
-        <div className={styles.summaryInfo} />
+        {showSummaryInfo && <div className={styles.summaryInfo} />}
       </SectionWrapper>
     </div>
   );

--- a/components/molecules/BannerContainer/BannerContainer.tsx
+++ b/components/molecules/BannerContainer/BannerContainer.tsx
@@ -13,7 +13,7 @@ import styles from "./BannerContainer.module.scss";
 type BannerContainerProperty = {
   className?: string;
   backgroundImage?: string;
-  bigTitle?: string;
+  primaryTitle?: string;
   subTitle?: string;
   subText?: string;
   buttonText?: string;
@@ -22,7 +22,7 @@ type BannerContainerProperty = {
 
 const BannerContainer: FC<BannerContainerProperty> = ({
   backgroundImage = "",
-  bigTitle = "",
+  primaryTitle = "",
   subTitle = "",
   subText = "",
   buttonText = "",
@@ -36,7 +36,7 @@ const BannerContainer: FC<BannerContainerProperty> = ({
     >
       <SectionWrapper className={styles.bannerContent}>
         <div className={styles.bannerInfo}>
-          {bigTitle && <SectionBigTitle title={bigTitle} />}
+          {primaryTitle && <SectionBigTitle title={primaryTitle} />}
           {subTitle && (
             <SubTitle title={subTitle} className={styles.subTitle} />
           )}

--- a/pages/home/Home.tsx
+++ b/pages/home/Home.tsx
@@ -9,7 +9,14 @@ import FAQSection from "components/templates/Home/FAQSection";
 
 const Home: NextPage = () => (
   <>
-    <BannerContainer backgroundImage="images/homepage/pics/banner.png" />
+    <BannerContainer
+      backgroundImage="images/homepage/pics/banner.png"
+      bigTitle="擁抱每一份獨特"
+      subTitle="第十九屆資訊種子培訓計畫"
+      subText="報名時間：2022/6/1-7/1"
+      buttonText="立即報名"
+      showSummaryInfo={true}
+    />
     <SummarySection />
     <IntroSection />
     <AlumniSection />

--- a/pages/home/Home.tsx
+++ b/pages/home/Home.tsx
@@ -11,7 +11,7 @@ const Home: NextPage = () => (
   <>
     <BannerContainer
       backgroundImage="images/homepage/pics/banner.png"
-      bigTitle="擁抱每一份獨特"
+      primaryTitle="擁抱每一份獨特"
       subTitle="第十九屆資訊種子培訓計畫"
       subText="報名時間：2022/6/1-7/1"
       buttonText="立即報名"


### PR DESCRIPTION
# Description
Since we have the same banner on all pages, I think we should let the banner component can customize each word.

## Home Page
![image](https://user-images.githubusercontent.com/33183531/145701649-ca331a07-505d-43eb-9244-199cf9d95fe5.png)

## About Page
![image](https://user-images.githubusercontent.com/33183531/145701658-2e379948-e6b5-4651-b531-175995461b1b.png)

## Graduates Page
![image](https://user-images.githubusercontent.com/33183531/145701639-6cd084e8-1131-4b20-86f2-0211fa66febd.png)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] see stage home page banner ( https://stage.itseed.tw/ )

![image](https://user-images.githubusercontent.com/33183531/145702088-06978b7d-806a-4b90-b4c3-2758a3b7bd1b.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules