### PR TITLE
Fix/Visitation page H2 margin bottom should change to 24px

### DIFF
--- a/components/molecules/ContentRender/ContentRender.module.scss
+++ b/components/molecules/ContentRender/ContentRender.module.scss
@@ -17,7 +17,7 @@
     font-size: 32px;
     font-weight: 500;
     line-height: 45px;
-    margin-bottom: 40px;
+    margin-bottom: 24px;
 
     @include mobile {
       font-size: 24px;


### PR DESCRIPTION
# Description
see the designer review in the [asana ticket](https://app.asana.com/0/1200963218344861/1201935447058515/f)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test it in this [URL](https://stage.itseed.tw/visitation#Google%20%E5%8F%B0%E7%81%A3)
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/33183531/174431403-1de333f6-d14c-4256-8234-c7d345073a1b.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules